### PR TITLE
changing synchronizeModel to use bulk api

### DIFF
--- a/.gitignore.orig
+++ b/.gitignore.orig
@@ -1,0 +1,23 @@
+<<<<<<< HEAD
+npm-debug.log
+node_modules
+._*
+.DS_Store
+.*.swp
+=======
+lib-cov
+*.seed
+*.log
+*.csv
+*.dat
+*.out
+*.pid
+*.gz
+
+pids
+logs
+results
+
+npm-debug.log
+node_modules
+>>>>>>> 60878575b16ac3d64a098c93d60c9f2502332f3a

--- a/lib/elasticgoose.js
+++ b/lib/elasticgoose.js
@@ -33,8 +33,8 @@ function ElasticMongoose() {
    };
 }
 
-ElasticMongoose.prototype.connect = function (/* Mongoose Object*/ mongoose, callback, options) {
-	this.mongoose = mongoose;
+ElasticMongoose.prototype.connect = function ( /* Mongoose Object*/ mongoose, callback, options) {
+   this.mongoose = mongoose;
    this.options = _.defaults({}, options || {}, this.options);
    this.initialized = true;
 
@@ -107,41 +107,52 @@ ElasticMongoose.prototype.synchronizeModel = function (modelName, callback) {
    var model = this.mongoose.model(modelName);
    var indexes = [];
    var item = [];
-   var count;
+   var count = 0;
 
-   var stream = model.find().stream();
-   stream.on('data', function (obj) {
-      item = _createBulkIndexData(obj, schema, options, function (item) {
-         indexes = indexes.concat(item);
-         if (indexes.length === self.options.bulkPush) {
-            self.debugCallback('Pushing ' + self.options.bulkPush + ' bulk items', '');
-            self.bulk(indexes);
-            indexes = [];
-         }
-         count++;
+   _getElasticKeysForSchema(schema, function (keys) {
+      var stream = model.find().stream();
+      stream.on('data', function (obj) {
+         stream.pause();
+         item = _createBulkIndexData(obj, schema, keys, options, function (item) {
+            indexes = indexes.concat(item);
+            if (count !== 0 && count % self.options.bulkPush === 0) {
+               self.debugCallback('Pushing ' + self.options.bulkPush + ' bulk items', '');
+               self.bulk(indexes, function () {
+                  indexes = [];
+               });
+            }
+            stream.resume();
+            count++;
+         });
+      }).on('error', function (err) {
+         self.errorCallback('synchronize operation failed', err);
+         callback(err);
+      }).on('close', function () {
+         // flush the indexes array
+         self.bulk(indexes);
+         self.debugCallback('streamed ' + count + ' from ' + modelName, '');
+         callback();
       });
-   }).on('error', function (err) {
-      self.errorCallback('synchronize operation failed', err);
-      callback(err);
-   }).on('close', function () {
-      // flush the indexes array
-      self.bulk(indexes);
-      self.debugCallback('streamed ' + count + ' from ' + modelName, '');
-      callback();
    });
 };
+
 
 ElasticMongoose.prototype.synchronizeAll = function (callback) {
    var errors = [];
 
    var onFinish = _.after(Object.keys(this.models).length, function () {
-      if (errors.length) callback(errors);
-      else callback();
+      if (errors.length) {
+         callback(errors);
+      } else {
+         callback();
+      }
    });
 
    for (var modelName in this.models) {
       this.synchronizeModel(modelName, function (err) {
-         if (err) errors.push(err);
+         if (err) {
+            errors.push(err);
+         }
          onFinish();
       });
    }
@@ -170,8 +181,11 @@ ElasticMongoose.prototype.search = function (options, query, callback, info) {
          from: options.from ? options.from : 0,
          size: options.size ? options.size : 10
       }, function (err, resp) {
-         if (err) deferred.reject(err);
-         else deferred.resolve(resp.hits);
+         if (err) {
+            deferred.reject(err);
+         } else {
+            deferred.resolve(resp.hits);
+         }
       });
 
       return deferred.promise;
@@ -234,10 +248,10 @@ ElasticMongoose.prototype.mongoosePlugin = function () {
       };
    }
 
-   function mapObject(type){
-   	self.mapping[type] = {
-   		type : 'object'
-   	};
+   function mapObject(type) {
+      self.mapping[type] = {
+         type: 'object'
+      };
    }
 
    return function (schema, options) {
@@ -253,12 +267,11 @@ ElasticMongoose.prototype.mongoosePlugin = function () {
          var elastic = schema.paths[key].options.elastic;
          if (elastic === 'geojson') {
             mapGeojson(options.type);
-         } else if(elastic === 'object'){
-         	mapObject(options.type);
+         } else if (elastic === 'object') {
+            mapObject(options.type);
          }
       }
       schema.post('save', function (obj) {
-         console.log("indexing product update");
          self.index(obj, schema, options);
       });
       schema.post('remove', function (obj) {
@@ -275,8 +288,11 @@ ElasticMongoose.prototype.remove = function (obj, options) {
       type: options.type,
       id: String(obj._id)
    }, function (err, resp) {
-      if (err) self.errorCallback('delete operation failed', err);
-      else if (!err) self.infoCallback('delete operation succeed', resp);
+      if (err) {
+         self.errorCallback('delete operation failed', err);
+      } else if (!err) {
+         self.infoCallback('delete operation succeed', resp);
+      }
    });
 };
 
@@ -284,8 +300,9 @@ ElasticMongoose.prototype.remove = function (obj, options) {
 function _getElasticKeysForSchema(schema, callback) {
    var elastics = [];
    for (var key in schema.paths) {
-      if (schema.paths[key].options.elastic)
+      if (schema.paths[key].options.elastic) {
          elastics.push(key);
+      }
    }
    callback(elastics);
 }
@@ -336,24 +353,20 @@ function _createFields(obj, schema, keys, cb) {
    );
 }
 
-function _createBulkIndexData(obj, schema, options, callback) {
+function _createBulkIndexData(obj, schema, keys, options, callback) {
    var self = this;
-   _getElasticKeysForSchema(schema, function (keys) {
-      _createFields(obj, schema, keys, function (fields) {
-         var result = [];
-
-         result = [{
-               'index': {
-                  '_index': options.index ? options.index : self.options.index,
-                  '_type': options.type,
-                  '_id': String(obj._id)
-               }
-            },
-            fields
-         ];
-
-         callback(result);
-      });
+   _createFields(obj, schema, keys, function (fields) {
+      var result = [];
+      result = [{
+            'index': {
+               '_index': options.index ? options.index : self.options.index,
+               '_type': options.type,
+               '_id': String(obj._id)
+            }
+         },
+         fields
+      ];
+      callback(result);
    });
 }
 
@@ -377,7 +390,7 @@ ElasticMongoose.prototype.index = function (obj, schema, options) {
 };
 
 
-ElasticMongoose.prototype.bulk = function (data) {
+ElasticMongoose.prototype.bulk = function (data, callback) {
    var self = this;
 
    // @todo: provide some validation here
@@ -387,6 +400,10 @@ ElasticMongoose.prototype.bulk = function (data) {
       function (err, resp) {
          if (err) self.errorCallback('bulk operation failed', err);
          else if (!err) self.infoCallback('bulk operation succeed', resp);
+         if (callback) {
+            callback();
+         }
+
       });
 };
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   },
   "name": "elasticgoose",
   "description": "Just a simple mongoose plugin for elastic search indexing",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "keywords": [
     "mongoose",
     "mongodb",


### PR DESCRIPTION
-- synchronizeModel was failing by making thousands of individual requests, so it now uses the bulk api
-- bulkPush can be fed into the options. this determines how many items it should collect before it makes a bulk call. 
-- changed some methods to private helper methods, to build the data structure two separate ways for .index and .bulk 
-- bumped the version number to 0.0.10
